### PR TITLE
fix: update Forge git email from vibekanban.com to genie@namastex.ai

### DIFF
--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -166,7 +166,7 @@ impl GitService {
         if !(has_name && has_email) {
             let mut cfg = repo.config()?;
             cfg.set_str("user.name", "Automagik Forge")?;
-            cfg.set_str("user.email", "noreply@vibekanban.com")?;
+            cfg.set_str("user.email", "genie@namastex.ai")?;
         }
         Ok(())
     }
@@ -178,7 +178,7 @@ impl GitService {
     ) -> Result<git2::Signature<'a>, GitServiceError> {
         match repo.signature() {
             Ok(sig) => Ok(sig),
-            Err(_) => git2::Signature::now("Automagik Forge", "noreply@vibekanban.com")
+            Err(_) => git2::Signature::now("Automagik Forge", "genie@namastex.ai")
                 .map_err(GitServiceError::from),
         }
     }

--- a/crates/services/tests/git_workflow.rs
+++ b/crates/services/tests/git_workflow.rs
@@ -70,7 +70,7 @@ fn initialize_repo_without_user_creates_initial_commit() {
         assert!(name.is_some() && email.is_some());
     } else {
         assert_eq!(name.as_deref(), Some("Automagik Forge"));
-        assert_eq!(email.as_deref(), Some("noreply@vibekanban.com"));
+        assert_eq!(email.as_deref(), Some("genie@namastex.ai"));
     }
 }
 
@@ -536,7 +536,7 @@ fn delete_file_commit_has_author_without_user() {
         assert!(name.is_some() && email.is_some());
     } else {
         assert_eq!(name.as_deref(), Some("Automagik Forge"));
-        assert_eq!(email.as_deref(), Some("noreply@vibekanban.com"));
+        assert_eq!(email.as_deref(), Some("genie@namastex.ai"));
     }
 }
 
@@ -641,6 +641,6 @@ fn squash_merge_libgit2_sets_author_without_user() {
         assert!(name.is_some() && email.is_some());
     } else {
         assert_eq!(name.as_deref(), Some("Automagik Forge"));
-        assert_eq!(email.as_deref(), Some("noreply@vibekanban.com"));
+        assert_eq!(email.as_deref(), Some("genie@namastex.ai"));
     }
 }


### PR DESCRIPTION
## Summary
Updates the hardcoded git email address used by Forge when making automated commits.

## Changes
- Replace all occurrences of `noreply@vibekanban.com` with `genie@namastex.ai`
- Updates both the GitService implementation and test assertions
- Aligns with current Automagik branding and namastex.ai domain

## Files Modified
- `crates/services/src/services/git.rs` - 2 occurrences updated
- `crates/services/tests/git_workflow.rs` - 3 test assertions updated

## Context
This addresses the legacy vibekanban domain that was still being used in automated commits. The new email `genie@namastex.ai` better represents the Automagik Forge identity.