### PR TITLE
fix: check-release-intent watches main branch (not dev)

### DIFF
--- a/.github/workflows/check-release-intent.yml
+++ b/.github/workflows/check-release-intent.yml
@@ -8,7 +8,7 @@ name: Check Release Intent
 on:
   pull_request:
     types: [closed]
-    branches: [dev]
+    branches: [main]
 
 jobs:
   check:
@@ -63,7 +63,7 @@ jobs:
             -d '{
               "repo": "${{ github.repository }}",
               "pr": ${{ github.event.pull_request.number }},
-              "branch": "dev",
+              "branch": "main",
               "type": "rc",
               "title": "${{ github.event.pull_request.title }}",
               "sha": "${{ github.event.pull_request.merge_commit_sha }}"


### PR DESCRIPTION
## Summary
forge-core has no `dev` branch. The workflow was incorrectly changed to watch `dev` in commit 488b738c, breaking release automation.

## Changes
- `branches: [dev]` → `branches: [main]` (line 11)
- `"branch": "dev"` → `"branch": "main"` (line 66)

## Note
**No release labels** - this is an administrative fix, not a release.